### PR TITLE
Nulls inserted incorrectly

### DIFF
--- a/Android/src/com/phonegap/plugin/sqlitePlugin/SQLitePlugin.java
+++ b/Android/src/com/phonegap/plugin/sqlitePlugin/SQLitePlugin.java
@@ -235,6 +235,8 @@ public class SQLitePlugin extends CordovaPlugin
 							myStatement.bindDouble(j + 1, jsonparams[i].getDouble(j));
 						} else if (jsonparams[i].get(j) instanceof Number) {
 							myStatement.bindLong(j + 1, jsonparams[i].getLong(j));
+						} else if (jsonparams[i].isNull(j)) {
+							myStatement.bindNull(j + 1);
 						} else {
 							myStatement.bindString(j + 1, jsonparams[i].getString(j));
 						}


### PR DESCRIPTION
...LitePlugin-Android#015

This bug currently results in the text "null" being inserted when null is inserted into a string field. The fix results in the field correctly being set to null instead of the strings "null".

The ios branch does not suffer from the same issue.

Credit to @huygo88
