### PR TITLE
Update SQLitePlugin.java ==> add rowAffected in response

### DIFF
--- a/Android/src/com/phonegap/plugin/sqlitePlugin/SQLitePlugin.java
+++ b/Android/src/com/phonegap/plugin/sqlitePlugin/SQLitePlugin.java
@@ -241,8 +241,13 @@ public class SQLitePlugin extends CordovaPlugin
 						}
 					}
 					long insertId = myStatement.executeInsert();
+					
+					long rowsAffected = 1;
+					if (insertId == -1) {
+						rowsAffected = 0;
+					}
 
-					String result = "{'insertId':'" + insertId + "'}";
+					String result = "{'insertId':'" + insertId + "', 'rowsAffected':'" + rowsAffected +"'}";
 					this.sendJavascriptCB("window.SQLitePluginTransactionCB.queryCompleteCallback('" +
 						tx_id + "','" + query_id + "', " + result + ");");
 				} else {


### PR DESCRIPTION
A little different thing between the ios plugin and the android plugin may cause a little problem. If we use the rowsAffected variable for a test in the callback function of executesql, this condition may be true only on ios.
